### PR TITLE
Add support for Librem 5 internal SC reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # smartcard-luks-osk
 
-OpenPGP smartcard setup with Linux boot for the PinePhone with Mobian (Librem 5 with PureOS might also work).
+OpenPGP smartcard setup with Linux boot for the PinePhone with Mobian (Librem 5 with PureOS also also works).
 This is a modified version of the Luks GPG encryption configuration Script from Purism (https://source.puri.sm/pureos/packages/smartcard-key-luks). This version is extended to replace the standard decrypt_gnupg-sc keyscript and use a custom version of the keyscript that integrates the osk by Postmarket OS (https://gitlab.com/postmarketOS/osk-sdl).
 The modified keyscript (files/decrypt_gnupg-sc-osk) will try to use the smartcard for around 90 secondes. After that the keyboard will be shown too, but the output is then directly forwarded without first going through gpg. If you still have a Luks keyslot with a normal passphrase, this can be used as a fallback, as every keyslot will be checked. If you get the on screen keyboard before 90 seconds are over, this means the smartcard was detected and you need to provide your pin for the gpg key and not a passphrase for a different Luks keyslot.
 
@@ -23,7 +23,9 @@ I noticed some problems with the recognition of my USB smartcard. Based on the l
 1. cd into the folder of the repository
 2. ./smartcard-luks-osk "your public key (file)" "device name"
 
-For now there is only the pinephone. You can hand over "pinephone" or "pp" as device values. This will ensure the anx7688 kernel module (USB-C port controller) will be loaded in the initramfs.
+For now there are two device options:
+"pinephone" or "pp" will ensure the anx7688 kernel module (USB-C port controller) will be loaded in the initramfs.
+"librem5" or "l5" will ensure the internal Librem 5 smart card reader is enabled
 
 ## Steps the script performs
 
@@ -33,7 +35,8 @@ For now there is only the pinephone. You can hand over "pinephone" or "pp" as de
 5. Creating new initramfs hook (/usr/share/initramfs-tools/hooks/cryptgnupg-sc-osk)
 6. Copying new keyscript to /lib/cryptsetup/scripts/decrypt_gnupg-sc-osk
 7. Adding anx7688 to /etc/initramfs-tools/modules if device is pinephone
-8. Adding keyfile to crypttab, replacing keyscript entry in crypttab
+8. Adding extra hooks and scripts to /usr/share/initramfs-tools/ if device is Librem 5
+9. Adding keyfile to crypttab, replacing keyscript entry in crypttab
 
 ## License
 

--- a/files/cryptgnupg-sc-osk-hook
+++ b/files/cryptgnupg-sc-osk-hook
@@ -82,17 +82,11 @@ mkdir -p -- "$DESTDIR/etc/opensc" "$DESTDIR/usr/lib/pcsc" "$DESTDIR/var/run" "$D
 copy_exec /usr/sbin/pcscd
 
 cp -rt "$DESTDIR/usr/lib" /usr/lib/pcsc
-cp -t "$DESTDIR/etc" /etc/reader.conf || true
 cp -rt "$DESTDIR/etc" /etc/reader.conf.d || true
 cp -t "$DESTDIR/etc" /etc/libccid_Info.plist
 
 for so in $(ldconfig -p | sed -nr 's/^\s*(libusb-[0-9.-]+|libpcsclite)\.so\.[0-9]+\s.*=>\s*//p'); do
     copy_exec "$so"
 done
-
-# Install opensc commands and conf file
-copy_exec /usr/bin/opensc-tool
-copy_exec /usr/bin/pkcs15-crypt
-cp -t "$DESTDIR/etc/opensc" /etc/opensc/opensc.conf
 
 exit $RV

--- a/files/cryptgnupg-sc-osk-hook
+++ b/files/cryptgnupg-sc-osk-hook
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+set -e
+
+PREREQ="cryptroot"
+
+prereqs()
+{
+        echo "$PREREQ"
+}
+
+case "$1" in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+. /lib/cryptsetup/functions
+
+if [ ! -x "$DESTDIR/lib/cryptsetup/scripts/decrypt_gnupg-sc-osk" ] || [ ! -f "$TABFILE" ]; then
+    exit 0
+fi
+
+# Hooks for loading gnupg software and encrypted key into the initramfs
+copy_keys() {
+    crypttab_parse_options
+    if [ "${CRYPTTAB_OPTION_keyscript-}" = "/lib/cryptsetup/scripts/decrypt_gnupg-sc-osk" ]; then
+        if [ -f "$CRYPTTAB_KEY" ]; then
+            [ -f "$DESTDIR$CRYPTTAB_KEY" ] || copy_file keyfile "$CRYPTTAB_KEY" || RV=$?
+        else
+            cryptsetup_message "ERROR: Target $CRYPTTAB_NAME has a non-existing key file $CRYPTTAB_KEY"
+            RV=1
+        fi
+    fi
+}
+
+RV=0
+crypttab_foreach_entry copy_keys
+
+PUBRING="/etc/cryptsetup-initramfs/pubring.gpg"
+if [ ! -f "$PUBRING" ]; then
+    cryptsetup_message "WARNING: $PUBRING: No such file"
+else
+    [ -d "$DESTDIR/cryptroot/gnupghome" ] || mkdir -pm0700 "$DESTDIR/cryptroot/gnupghome"
+    # let gpg(1) create the keyring on the fly; we're not relying on its
+    # internals since it's the very same binary we're copying to the
+    # initramfs
+    /usr/bin/gpg --no-options --no-autostart --trust-model=always \
+        --quiet --batch --no-tty --logger-file=/dev/null \
+        --homedir="$DESTDIR/cryptroot/gnupghome" --import <"$PUBRING"
+    # make sure not to clutter the initramfs with backup keyrings
+    find "$DESTDIR/cryptroot" -name "*~" -type f -delete
+fi
+
+copy_exec /usr/bin/gpg
+copy_exec /usr/bin/gpg-agent
+copy_exec /usr/lib/gnupg/scdaemon
+copy_exec /usr/bin/gpgconf
+copy_exec /usr/bin/gpg-connect-agent
+
+if [ ! -x "$DESTDIR/usr/bin/pinentry" ]; then
+    if [ -x "/usr/bin/pinentry-curses" ]; then
+        pinentry="/usr/bin/pinentry-curses"
+    elif [ -x "/usr/bin/pinentry-tty" ]; then
+        pinentry="/usr/bin/pinentry-tty"
+    else
+        cryptsetup_message "ERROR: missing required binary pinentry-curses or pinentry-tty"
+        RV=1
+    fi
+    copy_exec "$pinentry"
+    ln -s "$pinentry" "$DESTDIR/usr/bin/pinentry"
+fi
+[ -f "$DESTDIR/lib/terminfo/l/linux" ] || copy_file terminfo /lib/terminfo/l/linux || RV=$?
+
+# Install directories needed by smartcard reading daemon, command, and
+# key-script
+mkdir -p -- "$DESTDIR/etc/opensc" "$DESTDIR/usr/lib/pcsc" "$DESTDIR/var/run" "$DESTDIR/tmp"
+
+# Install pcscd daemon, drivers, conf file
+copy_exec /usr/sbin/pcscd
+
+cp -rt "$DESTDIR/usr/lib" /usr/lib/pcsc
+cp -t "$DESTDIR/etc" /etc/reader.conf || true
+cp -rt "$DESTDIR/etc" /etc/reader.conf.d || true
+cp -t "$DESTDIR/etc" /etc/libccid_Info.plist
+
+for so in $(ldconfig -p | sed -nr 's/^\s*(libusb-[0-9.-]+|libpcsclite)\.so\.[0-9]+\s.*=>\s*//p'); do
+    copy_exec "$so"
+done
+
+# Install opensc commands and conf file
+copy_exec /usr/bin/opensc-tool
+copy_exec /usr/bin/pkcs15-crypt
+cp -t "$DESTDIR/etc/opensc" /etc/opensc/opensc.conf
+
+exit $RV

--- a/files/cryptgnupg-sc-osk-script
+++ b/files/cryptgnupg-sc-osk-script
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+PREREQ=""
+
+prereqs()
+{
+    echo "$PREREQ"
+}
+
+case $1 in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+if [ ! -f /sys/class/leds/smc_en/brightness ]; then
+    exit 0
+fi
+
+# Initialize Librem 5 smart card reader
+echo 1 > /sys/class/leds/smc_en/brightness && sleep 5

--- a/smartcard-luks-osk
+++ b/smartcard-luks-osk
@@ -163,7 +163,7 @@ then
 fi
 
 # Configure Librem 5 internal smart card reader if present
-if [ -f /sys/class/leds/smc_en_brightness ]; then
+if [ -f /sys/class/leds/smc_en/brightness ]; then
   if [ "${MY_DEVICE}" = "librem5" ] || [ "${MY_DEVICE}" = "Librem5" ] || [ "${MY_DEVICE}" = "Librem 5" ] || [ "${MY_DEVICE}" = "librem 5" ] || [ "${MY_DEVICE}" = "l5" ]
   then
     cp "files/cryptgnupg-sc-osk-hook" "${GNUPGSC_OSK_HOOK}" && chmod 755 "${GNUPGSC_OSK_HOOK}"

--- a/smartcard-luks-osk
+++ b/smartcard-luks-osk
@@ -166,11 +166,11 @@ fi
 if [ -f /sys/class/leds/smc_en_brightness ]; then
   if [ "${MY_DEVICE}" = "librem5" ] || [ "${MY_DEVICE}" = "Librem5" ] || [ "${MY_DEVICE}" = "Librem 5" ] || [ "${MY_DEVICE}" = "librem 5" ] || [ "${MY_DEVICE}" = "l5" ]
   then
-		cp "files/cryptgnupg-sc-osk-hook" "${GNUPGSC_OSK_HOOK}" && chmod 755 "${GNUPGSC_OSK_HOOK}"
-		cp "files/cryptgnupg-sc-osk-script" "/usr/share/initramfs-tools/scripts/local-top/cryptgnupg-sc-osk" && chmod 755 "/usr/share/initramfs-tools/scripts/local-top/cryptgnupg-sc-osk"
+    cp "files/cryptgnupg-sc-osk-hook" "${GNUPGSC_OSK_HOOK}" && chmod 755 "${GNUPGSC_OSK_HOOK}"
+    cp "files/cryptgnupg-sc-osk-script" "/usr/share/initramfs-tools/scripts/local-top/cryptgnupg-sc-osk" && chmod 755 "/usr/share/initramfs-tools/scripts/local-top/cryptgnupg-sc-osk"
     echo "Configured internal Librem 5 smart card reader"
   else
-		echo "Librem5 parameter not given, not configuring internal smart card reader"
+    echo "Librem5 parameter not given, not configuring internal smart card reader"
   fi
 fi
 

--- a/smartcard-luks-osk
+++ b/smartcard-luks-osk
@@ -26,6 +26,12 @@ fi
 
 # Discover the root LUKS device
 ROOT_LUKS=`grep -v '^#' /etc/fstab | col | egrep '[[:space:]]+\/[[:space:]]+' | cut -f1 -d ' '| sed 's/\/dev\/mapper\///'`
+case $ROOT_LUKS in
+UUID=*)
+  UUID=`echo $ROOT_LUKS | cut -f2 -d '='`
+  ROOT_LUKS=`blkid -U $UUID | sed 's/\/dev\/mapper\///'`
+  ;;
+esac
 crypttab_find_entry $ROOT_LUKS
 ROOT_DEV=$CRYPTTAB_SOURCE
 
@@ -153,6 +159,18 @@ then
   else
       echo "Pinephone parameter not given, not adding kernel module anx7688 (for the USB-C controller of the PinePhone) to /etc/initramfs-tools/modules"
       echo "Make sure the module is loaded in the initramfs kernel if you want to use the USB-C port to connect a smart-card"
+  fi
+fi
+
+# Configure Librem 5 internal smart card reader if present
+if [ -f /sys/class/leds/smc_en_brightness ]; then
+  if [ "${MY_DEVICE}" = "librem5" ] || [ "${MY_DEVICE}" = "Librem5" ] || [ "${MY_DEVICE}" = "Librem 5" ] || [ "${MY_DEVICE}" = "librem 5" ] || [ "${MY_DEVICE}" = "l5" ]
+  then
+		cp "files/cryptgnupg-sc-osk-hook" "${GNUPGSC_OSK_HOOK}" && chmod 755 "${GNUPGSC_OSK_HOOK}"
+		cp "files/cryptgnupg-sc-osk-script" "/usr/share/initramfs-tools/scripts/local-top/cryptgnupg-sc-osk" && chmod 755 "/usr/share/initramfs-tools/scripts/local-top/cryptgnupg-sc-osk"
+    echo "Configured internal Librem 5 smart card reader"
+  else
+		echo "Librem5 parameter not given, not configuring internal smart card reader"
   fi
 fi
 


### PR DESCRIPTION
These changes add support for the internal Librem 5 smart card reader. I
had to modify the hook script to ensure that pcscd files were copied
over properly, as well as adding a new local-top script for initramfs so
that the internal smart card reader device was activated.